### PR TITLE
Step 26: mail best-effort + plan warning dedupe

### DIFF
--- a/apps/api/src/handlers/devices/register-confirm.ts
+++ b/apps/api/src/handlers/devices/register-confirm.ts
@@ -15,8 +15,14 @@ import {
 } from "../../modules/devices/deviceRegistrationLinks.db.js";
 import type { DbClientLike } from "../../modules/devices/deviceRegistrationLinks.repo.js";
 
-type DeviceRegistrationConfirmDeps = Omit<DeviceOnboardingServiceDeps, "repo"> & {
+type DeviceRegistrationConfirmDeps = Omit<
+  DeviceOnboardingServiceDeps,
+  "repo" | "mail" | "audit" | "logger"
+> & {
   db: DbClientLike;
+  mail?: DeviceOnboardingServiceDeps["mail"];
+  audit?: DeviceOnboardingServiceDeps["audit"];
+  logger?: DeviceOnboardingServiceDeps["logger"];
 };
 
 export async function handleDeviceRegistrationConfirm(

--- a/apps/api/src/modules/devices/deviceOnboarding.service.ts
+++ b/apps/api/src/modules/devices/deviceOnboarding.service.ts
@@ -169,10 +169,22 @@ export function createDeviceOnboardingService(
         await deps.activeDeviceStore.markActive({ tenantId, deviceId });
       }
 
-      await mail?.sendDeviceBoundAlert({
-        tenantId,
-        deviceId,
-      });
+      try {
+        await mail?.sendDeviceBoundAlert({ tenantId, deviceId });
+      } catch {
+        logger?.warn?.("mail send failed", {
+          tenantId,
+          deviceId,
+          template: "device_bound_alert",
+        });
+        await Promise.resolve(
+          audit?.log("mail.send_failed", {
+            tenantId,
+            deviceId,
+            template: "device_bound_alert",
+          }),
+        );
+      }
 
       await audit?.log("device.registration.confirmed", {
         tenantId,

--- a/apps/api/src/plan/plan-policy.spec.ts
+++ b/apps/api/src/plan/plan-policy.spec.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { createPlanUsageTracker } from "./plan-policy.js";
+import { InMemoryPlanWarningDedupStore } from "./plan-dedup-store.js";
+
+describe("createPlanUsageTracker", () => {
+  const originalStarterLimit = process.env.PLAN_LIMIT_STAMPS_STARTER;
+
+  afterEach(() => {
+    process.env.PLAN_LIMIT_STAMPS_STARTER = originalStarterLimit;
+    vi.useRealTimers();
+  });
+
+  it("dedupes plan warning within 24 hours", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2025-01-01T00:00:00.000Z"));
+    process.env.PLAN_LIMIT_STAMPS_STARTER = "1";
+
+    const planStore = {
+      getPlan: async () => "starter" as const,
+    };
+    const warningDedupStore = new InMemoryPlanWarningDedupStore(() => Date.now());
+    const tracker = createPlanUsageTracker({
+      planStore,
+      warningDedupStore,
+      now: () => new Date(),
+    });
+
+    const first = await tracker.recordStamp({
+      tenantId: "tenant-1",
+      plan: "starter",
+      correlationId: "corr-1",
+    });
+    expect(first?.threshold).toBe(100);
+    expect(first?.shouldNotify).toBe(true);
+
+    const second = await tracker.recordStamp({
+      tenantId: "tenant-1",
+      plan: "starter",
+      correlationId: "corr-2",
+    });
+    expect(second?.threshold).toBe(100);
+    expect(second?.shouldNotify).toBe(false);
+
+    vi.advanceTimersByTime(24 * 60 * 60 * 1000 + 1);
+
+    const third = await tracker.recordStamp({
+      tenantId: "tenant-1",
+      plan: "starter",
+      correlationId: "corr-3",
+    });
+    expect(third?.threshold).toBe(100);
+    expect(third?.shouldNotify).toBe(true);
+  });
+});


### PR DESCRIPTION
Beschreibung

Device onboarding: mail delivery is best-effort; confirm remains successful if mail fails.

Audit signal on mail failure: mail.send_failed with template metadata.

Handler deps: mail/audit/logger are optional to support test wiring.

Plan warnings: 24h dedupe behavior covered by unit test (plan-policy.spec.ts).

App server: optional mail dependency injection for plan-limit warnings; fire-and-forget with audit fallback on failures.

Verification

npm run lint -w @lokaltreu/api

npm test -w @lokaltreu/api